### PR TITLE
Update happo-cypress to 1.3.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1823,9 +1823,9 @@
       "integrity": "sha1-Dovf5NHduIVNZOBOp8AOKgJuVlg="
     },
     "happo-cypress": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/happo-cypress/-/happo-cypress-1.0.0.tgz",
-      "integrity": "sha512-PO50kvSLVevwaCw8mmWTbe3LsXYZPIRFPiV/r9h3sgjsLHCVjguAPaAm+3n9yJBimV4x1J9udoLrsDaY+eBhPw==",
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/happo-cypress/-/happo-cypress-1.3.0.tgz",
+      "integrity": "sha512-oeYcWGB1M1eqRnG/sZBYzbg07VMo8o59gmL6D6Hdlbl/FlQceNVgvqPVenpqxvUMN15C+FqLPhQvrlmVVprLXA==",
       "dev": true,
       "requires": {
         "archiver": "^3.1.1",

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "eslint": "6.8.0",
     "eslint-plugin-cypress-dev": "3.0.0",
     "eslint-plugin-mocha": "5.3.0",
-    "happo-cypress": "1.0.0",
+    "happo-cypress": "1.3.0",
     "happo.io": "5.4.0",
     "npm-run-all": "4.1.5",
     "typescript": "3.7.4"


### PR DESCRIPTION
We don't need anything from this release, but I wanted to make sure
we're on the latest version to make sure we're not breaking anything.